### PR TITLE
Make sure all resources have been added on finalize()

### DIFF
--- a/test/resource.spec.ts
+++ b/test/resource.spec.ts
@@ -86,4 +86,35 @@ describe('read/write resources failures', () => {
 			expect(error.message).to.equal('Adding unknown resource "world"');
 		}
 	});
+
+	it('finalize without all resources added', async () => {
+		const myBundle = bundle.create({
+			type: 'foo@1',
+			manifest: ['hello.txt', 'world.txt'],
+			resources: [
+				{
+					id: 'hello',
+					size: 5,
+					digest:
+						'sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824',
+				},
+				{
+					id: 'world',
+					size: 5,
+					digest:
+						'sha256:486ea46224d1bb4fb680f34f7c9ad96a8f24ec88be73ea8e5a6c65260e9cb8a7',
+				},
+			],
+		});
+
+		const hello = stringToStream('hello');
+		await myBundle.addResource('hello', hello);
+
+		try {
+			await myBundle.finalize();
+			expect.fail('Unreachable');
+		} catch (error) {
+			expect(error.message).to.equal('Resource "world" was not added');
+		}
+	});
 });


### PR DESCRIPTION
Also no longer support adding resources in parallel without invoking await as after adding the new tests for `finalize()` it was found out that it does not work correctly.
