### PR TITLE
Fix Node.js runtime exiting when manifest size is too big

### DIFF
--- a/src/readable.ts
+++ b/src/readable.ts
@@ -37,10 +37,10 @@ class ReadableBundle<T> {
 
 		const entry: tar.Entry = (await this.iterator.next()).value;
 
-		const entrySig: tar.Entry = (await this.iterator.next()).value;
-
 		const contentsRes = new Response(entry as any);
 		const contentsStr = await contentsRes.text();
+
+		const entrySig: tar.Entry = (await this.iterator.next()).value;
 
 		const contentsSigRes = new Response(entrySig as any);
 		const contentsSig = await contentsSigRes.json();


### PR DESCRIPTION
When reading a resource bundle with big manifest file, we did not attach immediately the tar entry stream for contents.json, but instead iterated next to the contents.sig tar entry. For bigger contents.json files that would drain only the start of the contents.json file, but not the rest of it, which in turn caused the Node.js runtime to exit immediately with exit status 13.

Now we properly order iterating and reading the contents of the contents.json and contents.sig files.
