### PR TITLE
Add helper to fetch multiple images more efficiently

### DIFF
--- a/src/docker/registry.ts
+++ b/src/docker/registry.ts
@@ -67,23 +67,16 @@ export async function authenticate(
 		);
 	}
 
-	const result = await response.json();
+	const { token } = await response.json();
 
-	if (result.token == null) {
+	if (token == null) {
 		throw new Error('No token in authentication response');
 	}
 
-	return result.token;
-}
-
-function unparseImageName(image: ImageDescriptor): string {
-	const { registry, repository, reference } = image;
-	const sep = reference.startsWith('sha256:') ? '@' : ':';
-	return `${registry}/${repository}${sep}${reference}`;
+	return token;
 }
 
 /**
- *
  * @param image a descriptor for the image to fetch
  * @param token (optional) a JWT that authorizes access to the image
  */
@@ -94,28 +87,70 @@ export async function fetchImage(
 	image: Image;
 	blobs: Resource[];
 }> {
-	const manifest = await fetchImageManifest(image, token);
+	const { images, blobs } = await fetchImages([image], token);
+	if (images.length !== 1) {
+		throw new Error('Unreachable');
+	}
+	return { image: images[0], blobs };
+}
 
-	const blobs = [manifest.config, ...manifest.layers];
-	const digests = new Set<string>();
-	const resources = new Array<Resource>();
-
-	for (const blob of blobs) {
-		if (digests.has(blob.digest)) {
-			continue;
-		}
-		digests.add(blob.digest);
-
-		resources.push({
-			id: blob.digest,
-			size: blob.size,
-			digest: blob.digest,
-			type: blob.mediaType,
-			data: await fetchImageBlob(image, blob, token),
-		});
+/**
+ * Like `fetchImage` but this one ensures that layers shared between
+ * the given images are only included once.
+ *
+ * @param image an array of descriptors for the images to fetch
+ * @param token (optional) a JWT that authorizes access to the images
+ */
+export async function fetchImages(
+	images: ImageDescriptor[],
+	token?: string,
+): Promise<{
+	images: Image[];
+	blobs: Resource[];
+}> {
+	const registries = new Set<string>();
+	images.forEach(({ registry }) => registries.add(registry));
+	if (registries.size > 1) {
+		throw new Error(
+			'Refusing to fetch images from multiple registries using the same token',
+		);
 	}
 
-	return { image: { descriptor: image, manifest }, blobs: resources };
+	const result = {
+		images: new Array<Image>(),
+		blobs: new Array<Resource>(),
+	};
+
+	const digests = new Set<string>();
+
+	await Promise.all(
+		images.map(async (image) => {
+			const manifest = await fetchImageManifest(image, token);
+
+			result.images.push({ descriptor: image, manifest });
+
+			const blobs = [manifest.config, ...manifest.layers];
+
+			for (const blob of blobs) {
+				if (digests.has(blob.digest)) {
+					continue;
+				}
+				digests.add(blob.digest);
+
+				const data = await fetchImageBlob(image, blob, token);
+
+				result.blobs.push({
+					id: blob.digest,
+					size: blob.size,
+					digest: blob.digest,
+					type: blob.mediaType,
+					data,
+				});
+			}
+		}),
+	);
+
+	return result;
 }
 
 function getDefaultHeaders(token?: string): { [name: string]: string } {
@@ -129,11 +164,17 @@ function getDefaultHeaders(token?: string): { [name: string]: string } {
 	return headers;
 }
 
+function unparseImageName(image: ImageDescriptor): string {
+	const { registry, repository, reference } = image;
+	const sep = reference.startsWith('sha256:') ? '@' : ':';
+	return `${registry}/${repository}${sep}${reference}`;
+}
+
 async function fetchImageManifest(
 	image: ImageDescriptor,
 	token?: string,
 ): Promise<ImageManifest> {
-	const url = `http://${image.registry}/v2/${image.repository}/manifests/${image.reference}`;
+	const url = `https://${image.registry}/v2/${image.repository}/manifests/${image.reference}`;
 
 	const res = await fetch(url, {
 		headers: {


### PR DESCRIPTION
`fetchImages` can deduplicate layers shared between the given images and only include them once.

Change-type: patch