### PR TITLE
Embed image manifests in base64 form

### DIFF
--- a/src/docker/types.ts
+++ b/src/docker/types.ts
@@ -20,4 +20,5 @@ export interface ImageDescriptor {
 export interface Image {
 	descriptor: ImageDescriptor;
 	manifest: ImageManifest;
+	manifestBase64: string;
 }


### PR DESCRIPTION
Include image manifests in base64 form when fetching images from a registry. The original manifest must be retained to enable pushing images back to a registry. When the image reference is in sha256 form, it is equivalent to the original manifest checksum.
